### PR TITLE
deduplicate purchase events

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -74,5 +74,7 @@ models:
           +enabled: true 
         stg_ga4__event_purchase:
           +enabled: true
+        stg_ga4__event_purchase_deduplicated:
+          +enabled: true
         stg_ga4__event_view_item:
           +enabled: true 

--- a/models/marts/fct_ga4__event_purchase.sql
+++ b/models/marts/fct_ga4__event_purchase.sql
@@ -55,7 +55,7 @@ select
     , tax 
     , shipping 
     , affiliation 
-from {{ ref('stg_ga4__event_purchase') }}
+from {{ ref('stg_ga4__event_purchase_deduplicated') }}
 {% if is_incremental() %}
     where event_date_dt in ({{ partitions_to_replace | join(',') }})
 {% endif %}


### PR DESCRIPTION
Enabled the staging deduplication model and update the reference in `fct_ga4__event_purchase` to use the dedup model.